### PR TITLE
Rewrite profile README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,37 @@
-## 👋 Greetings, I'm Max a Technical Architect and Cloud Enthusiast
+# Max Hutchinson
 
-I am an Aspiring Technical Architect with over a decade of experience in the technology industry. Currently, I am honing my skills in architectural roles, specializing in designing and implementing data-intensive applications. My expertise lies in addressing complex scalability and data transformation challenges, thereby delivering customized solutions that drive significant business value.
+C# Technology Lead and Technical Architect focused on distributed and deterministic systems.
 
-### 🌱 Professional Growth and Aspirations
-I am actively seeking opportunities to expand my experience in Azure cloud, .Net, C#, Serverless, and Microservice Solutions. My commitment to continuous learning fuels my goal to lead and innovate in user-centric projects, consistently evolving my skills to meet the dynamic needs of the industry.
+I build event-driven platforms that must behave predictably under load, remain operable under failure, and support replayable, auditable workflows. My work spans regulated data platforms, high-throughput ingestion, and integration architectures where correctness and failure isolation matter.
 
-### 🔧 Skills & Expertise
+## What I build
 
-* **Programming Languages:** C#, LINQ, SQL, Python
-* **Cloud Platforms:** Azure (Azure Functions, Logic Apps, Service Bus, Event Hubs)
-* **Technologies:** .Net, Entity Framework Core, Hot Chocolate, REST, GraphQL, CI/CD
-* **Databases:** SQL Server, Azure Storage, Cosmos DB, Azure SQL
-* **Preferred Architecture:** Serverless, PaaS, FaaS, Containers
-* **Design Principles:** Domain-Driven Design (DDD), Clean Architecture, software patterns
+### Platforms
+Distributed systems, integration architecture, ingestion pipelines, and observability-first operations.
 
-### 🚀 Key Projects & Accomplishments
-* **The Pensions Regulator:** Led the development and deployment of multiple new domains, systems, and microservices to automate “Automatic Enrolment” enforcement cases, handling over £4 trillion into reliable pension schemes. Upskilled and matured the development of several teams and directorates with EDA, DDD, and mature development practices through thought leadership.
-* **CI&T and Somo Global:** Successfully led the integration of GraphQL API and event-driven platforms, implementing microservices and streamlining data flow, resulting in significant cost savings and operational efficiencies.
-* **VRAI:** Architected and led the development of idempotent cloud data ingestion systems using serverless principles, facilitating robust data analytics.
-* **MRI Software:** Transformed legacy business workflows into scalable, automated processes within a SaaS environment, and led the development of a dynamic Data Warehousing system.
+### Quant Systems
+Exploratory work on systematic trading system design with an emphasis on determinism, replay semantics, execution workflow modelling, and risk-aware controls. This focuses on infrastructure design principles rather than strategy development.
 
-### 🚀 Projects & Accomplishments
+### Agentic Systems
+Agent orchestration patterns designed for production: policy gates, tool constraints, evaluation loops, and human-in-the-loop workflows that remain observable and governable.
 
-* Architected and implemented cloud-native, scalable systems for multiple clients
-* Designed and developed a serverless & scalable VR data ingestion service for real-time analytics
-* Successfully migrated a monolithic application to a microservices architecture, improving resilience and maintainability
-* Mentored and led a team of engineers in adopting best practices in software development, cloud architecture, DDD, Clean Architecture, and key software patterns
+## Principles
 
-### 📚 Continuous Learning
+- Radical simplicity
+- Minimise technical debt and system surface area
+- Reduce costs appropriately
+- Enable talent, to talent: strong guardrails, high autonomy
 
-As a firm believer in lifelong learning, I continuously seek to stay ahead of technological advancements. I actively participate in workshops, conferences, and online training.
+## Engineering standards
 
-### ☕ Max's Professional Journey
+- Determinism and replayability by design
+- Operability first (instrumentation, debugging, failure modes)
 
-Having worked in various roles from Software Engineer to Technical Architect, I've honed my skills in cloud data infrastructure, serverless APIs, and event-based architectures. My experience includes significant contributions at CI&T, Somo Global, VRAI, and MRI Software, where I've led teams and projects to deliver innovative cloud solutions.
+## Background
 
-### 🌐 Connect with Max
+12+ years building C# distributed systems across regulated and high-consequence environments including national regulation, energy platforms, SaaS systems, and real-time telemetry platforms.
 
-* [LinkedIn](https://www.linkedin.com/in/maxlauriehutchinson)
-* [Twitter](https://twitter.com/MaxLHutchinson)
-* [Personal Website](https://www.maxlauriehutchinson.co.uk/)
-* [GitHub](https://github.com/MaxLaurieHutchinson)
-* [Medium](https://medium.com/@MaxLaurieHutchinson)
+## Contact
 
-
+LinkedIn: https://www.linkedin.com/in/maxlauriehutchinson  
+Website: https://www.maxlauriehutchinson.co.uk


### PR DESCRIPTION
## Summary
- rewrite profile README with stronger senior architecture positioning
- balance broad architecture scope with quant and agentic systems focus
- replace principles and standards sections to reflect current working approach

## Notes
- removes older junior/aspirational phrasing
- keeps contact links concise