### PR TITLE
Reposition profile around Applied AI systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,62 +2,68 @@
 
 **Applied AI Systems Architect**
 
-I design AI-enabled workflows with clear decision rights, measurable behaviour
-and reliable operating paths.
+I build AI-enabled systems, distributed platforms and integration-heavy
+products. I care about what happens when the model is wrong, the queue backs up,
+the connection disappears, or a person needs to overrule the machine.
 
-My direct AI work is recent. The operating judgement behind it comes from more
-than 12 years across software engineering, technical leadership and architecture.
+My direct Applied AI work is recent. The engineering judgement behind it comes
+from more than 12 years of building and leading software in regulated,
+high-throughput and failure-prone environments.
 
+[Website](https://maxlauriehutchinson.co.uk/) |
 [Work](https://maxlauriehutchinson.co.uk/work/) |
-[Applied AI](https://maxlauriehutchinson.co.uk/projects/) |
 [Writing](https://maxlauriehutchinson.co.uk/writing/) |
 [LinkedIn](https://www.linkedin.com/in/maxlauriehutchinson)
 
-## What I work on
+## How I Build
 
-- **Operated workflows:** an AI-assisted asset workflow that a non-technical
-  team could run, with brand and publishing decisions retained by people.
-- **Consequential systems:** regulated ingestion, energy integration,
-  failure-tolerant edge telemetry and distributed reporting.
-- **Current R&D:** EvidenceGate, a working change-assurance prototype separating
-  deterministic checks, optional model findings and a named reviewer decision.
+- **Make state explicit.** If a workflow matters, I want to know what happened,
+  which version made the decision and how to reconstruct it.
+- **Treat recovery as product behaviour.** Retries, idempotency, backpressure,
+  rollback and human handover belong in the design, not in a later runbook.
+- **Keep hard boundaries around soft judgement.** Models can analyse and propose;
+  code, policy and named people decide what is allowed to happen.
+- **Use evidence to change direction.** Benchmarks, load tests, failure drills and
+  real operating constraints beat architectural fashion.
+- **Leave a system easier to own.** Good architecture should improve the next
+  engineer's decisions, not make the original architect indispensable.
 
-EvidenceGate includes a local hash-linked integrity check. It is implementation
-evidence, not proof of pilot use, enterprise adoption or business impact.
+## What I Am Building
 
-## Engineering standards I keep
-
-- **Deterministic control around probabilistic components:** code and policy own
-  permissions, limits and state transitions; models contribute where judgement
-  creates useful leverage.
-- **Inspectable decisions:** important paths retain the inputs, policy version,
-  model output, reviewer decision and outcome needed for explanation and replay.
-- **Failure-aware operation:** timeouts, retries, idempotency, fallbacks, rollback
-  and recovery ownership are designed as part of the workflow.
-- **Explicit accountability:** consequential decisions have named owners,
-  review thresholds, runbooks and a clear human handover.
-- **Earned autonomy:** start with a bounded workflow and measurable baseline;
-  expand autonomy only when evidence supports it.
-
-## Selected repositories
-
+- [EvidenceGate](https://maxlauriehutchinson.co.uk/projects/evidence-gate/): a
+  private proof of concept for engineering change assurance with deterministic
+  checks, optional model findings and a named reviewer decision. It has no
+  sponsoring organisation, external pilot or adoption claim.
 - [Intention Engine](https://github.com/MaxLaurieHutchinson/Agent-autonomous-intention-engine):
-  deterministic work discovery, risk routing and replay.
+  deterministic work discovery, risk routing and replay for agent workflows.
 - [Marketing Automation System](https://github.com/MaxLaurieHutchinson/marketing-automation-system):
-  evidence-led workflow design, human feedback and staged automation.
+  visible orchestration, human feedback and staged automation for a workflow
+  that non-technical owners can operate.
+
+## Systems Evidence
+
+- Deterministic ingestion and reconciliation across nine regulated data streams,
+  including late corrective data and replayable lineage.
+- Architecture across about 14 enterprise integrations, replacing a roughly
+  30-day process with seconds-level digital flow.
+- Edge-to-cloud telemetry for 153 multimodal signals at 30Hz per participant,
+  designed to keep working through unreliable connectivity.
+
+## Selected Code
+
 - [Fintech Account Operations](https://github.com/MaxLaurieHutchinson/fintech-account-operations):
   explicit domain behaviour, transactional consistency and post-commit effects.
+- [Quant Systems Lab](https://github.com/MaxLaurieHutchinson/quant-systems-lab):
+  event-driven simulation, replay, risk controls and market-system experiments.
+- [Agentic AI Skill Library](https://github.com/MaxLaurieHutchinson/skill-library):
+  versioned, testable capability packaging for agent platforms.
 
-These are implementation artefacts. Code volume is not adoption evidence.
+## Current Questions
 
-## Architecture thesis
+I am exploring how agent systems earn autonomy, how evaluation connects to live
+operating decisions, and what replay should mean when part of the decision path
+is probabilistic.
 
 > The model proposes. The system defines what can happen.
 
-I write about the boundaries that make that practical: decision ownership,
-evaluation, observability, replay, failure handling and operating handover.
-
 [Read: The Control Plane for Applied AI Workflows](https://maxlauriehutchinson.co.uk/writing/applied-ai-control-plane/)
-
-[Website](https://maxlauriehutchinson.co.uk/) |
-[Email](mailto:max.hutchinson258@gmail.com)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ and reliable operating paths.
 My direct AI work is recent. The operating judgement behind it comes from more
 than 12 years across software engineering, technical leadership and architecture.
 
-[Work](https://maxlauriehutchinson.co.uk/work/) ·
-[Applied AI](https://maxlauriehutchinson.co.uk/projects/) ·
-[Writing](https://maxlauriehutchinson.co.uk/writing/) ·
+[Work](https://maxlauriehutchinson.co.uk/work/) |
+[Applied AI](https://maxlauriehutchinson.co.uk/projects/) |
+[Writing](https://maxlauriehutchinson.co.uk/writing/) |
 [LinkedIn](https://www.linkedin.com/in/maxlauriehutchinson)
 
 ## What I work on
@@ -24,6 +24,20 @@ than 12 years across software engineering, technical leadership and architecture
 
 EvidenceGate includes a local hash-linked integrity check. It is implementation
 evidence, not proof of pilot use, enterprise adoption or business impact.
+
+## Engineering standards I keep
+
+- **Deterministic control around probabilistic components:** code and policy own
+  permissions, limits and state transitions; models contribute where judgement
+  creates useful leverage.
+- **Inspectable decisions:** important paths retain the inputs, policy version,
+  model output, reviewer decision and outcome needed for explanation and replay.
+- **Failure-aware operation:** timeouts, retries, idempotency, fallbacks, rollback
+  and recovery ownership are designed as part of the workflow.
+- **Explicit accountability:** consequential decisions have named owners,
+  review thresholds, runbooks and a clear human handover.
+- **Earned autonomy:** start with a bounded workflow and measurable baseline;
+  expand autonomy only when evidence supports it.
 
 ## Selected repositories
 
@@ -45,5 +59,5 @@ evaluation, observability, replay, failure handling and operating handover.
 
 [Read: The Control Plane for Applied AI Workflows](https://maxlauriehutchinson.co.uk/writing/applied-ai-control-plane/)
 
-[Website](https://maxlauriehutchinson.co.uk/) ·
+[Website](https://maxlauriehutchinson.co.uk/) |
 [Email](mailto:max.hutchinson258@gmail.com)

--- a/README.md
+++ b/README.md
@@ -53,17 +53,17 @@ enterprise adoption or general model quality.
 
 ## Selected Public Repositories
 
-- [Intention Engine](https://github.com/MaxLaurieHutchinson/Agent-autonomous-intention-engine)
-  - deterministic, file-first work discovery and risk routing with auditable runs
+- **[Intention Engine](https://github.com/MaxLaurieHutchinson/Agent-autonomous-intention-engine):**
+  deterministic, file-first work discovery and risk routing with auditable runs
   and replay.
-- [Marketing Automation System](https://github.com/MaxLaurieHutchinson/marketing-automation-system)
-  - evidence-led research, measurable workflows, human feedback and staged
+- **[Marketing Automation System](https://github.com/MaxLaurieHutchinson/marketing-automation-system):**
+  evidence-led research, measurable workflows, human feedback and staged
   autonomy in a practical teaching system.
-- [Agent Patterns Catalog](https://github.com/MaxLaurieHutchinson/agent-patterns)
-  - runnable Python implementations of planning, tool-use, reliability, memory
-  and event-driven coordination patterns.
-- [Fintech Account Operations](https://github.com/MaxLaurieHutchinson/fintech-account-operations)
-  - explicit domain behaviour, transactional consistency and post-commit effects
+- **[Agent Patterns Catalog](https://github.com/MaxLaurieHutchinson/agent-patterns):**
+  runnable Python implementations of planning, tool-use, reliability, memory and
+  event-driven coordination patterns.
+- **[Fintech Account Operations](https://github.com/MaxLaurieHutchinson/fintech-account-operations):**
+  explicit domain behaviour, transactional consistency and post-commit effects
   in a focused .NET sample.
 
 These repositories are implementation evidence. Maturity, adoption and business

--- a/README.md
+++ b/README.md
@@ -2,96 +2,48 @@
 
 **Applied AI Systems Architect**
 
-I design governed AI workflows and production platforms that teams can trust,
-operate and improve.
+I design AI-enabled workflows with clear decision rights, measurable behaviour
+and reliable operating paths.
 
-My direct AI delivery is recent; the systems judgement behind it comes from 12+
-years across distributed, event-driven and high-consequence systems. I focus on
-the control surfaces that let useful AI move beyond a demo: explicit state,
-bounded tool authority, policy, evaluation, human decisions, observability,
-replay and clear operating ownership.
+My direct AI work is recent. The operating judgement behind it comes from more
+than 12 years across software engineering, technical leadership and architecture.
 
-[Applied AI work](https://maxlauriehutchinson.co.uk/projects/) |
-[Enterprise cases](https://maxlauriehutchinson.co.uk/work/) |
-[Writing](https://maxlauriehutchinson.co.uk/writing/) |
+[Work](https://maxlauriehutchinson.co.uk/work/) ·
+[Applied AI](https://maxlauriehutchinson.co.uk/projects/) ·
+[Writing](https://maxlauriehutchinson.co.uk/writing/) ·
 [LinkedIn](https://www.linkedin.com/in/maxlauriehutchinson)
 
-## Evidence
+## What I work on
 
-### Operated Applied AI workflow
+- **Operated workflows:** an AI-assisted asset workflow that a non-technical
+  team could run, with brand and publishing decisions retained by people.
+- **Consequential systems:** regulated ingestion, energy integration,
+  failure-tolerant edge telemetry and distributed reporting.
+- **Current R&D:** EvidenceGate, a working change-assurance prototype separating
+  deterministic checks, optional model findings and a named reviewer decision.
 
-For Lem and Lira, I designed an AI-driven asset workflow using n8n and Azure
-Functions. It retained human review for brand and publishing decisions, reduced
-SKU go-to-market time by 90%, and removed reliance on external studio
-photography.
+EvidenceGate includes a local hash-linked integrity check. It is implementation
+evidence, not proof of pilot use, enterprise adoption or business impact.
 
-[Read the case](https://maxlauriehutchinson.co.uk/work/lem-lira-ai-asset-workflow/)
+## Selected repositories
 
-### Current flagship prototype
+- [Intention Engine](https://github.com/MaxLaurieHutchinson/Agent-autonomous-intention-engine):
+  deterministic work discovery, risk routing and replay.
+- [Marketing Automation System](https://github.com/MaxLaurieHutchinson/marketing-automation-system):
+  evidence-led workflow design, human feedback and staged automation.
+- [Fintech Account Operations](https://github.com/MaxLaurieHutchinson/fintech-account-operations):
+  explicit domain behaviour, transactional consistency and post-commit effects.
 
-EvidenceGate is a human-gated engineering change-assurance prototype. It combines
-deterministic controls, policy-cited model findings, named reviewer decisions and
-tamper-evident audit events.
+These are implementation artefacts. Code volume is not adoption evidence.
 
-Its current evidence is deliberately bounded: 12 passing tests and a four-scenario
-synthetic regression set. It is a pilot-ready architecture case, not a claim of
-enterprise adoption or general model quality.
+## Architecture thesis
 
-[Read the EvidenceGate case](https://maxlauriehutchinson.co.uk/projects/evidence-gate/)
+> The model proposes. The system defines what can happen.
 
-### Production systems foundation
-
-- **SSE Business Energy:** architecture across about 14 integrations; reduced a
-  roughly 30-day process to seconds-level digital processing.
-- **The Pensions Regulator:** deterministic ingestion and reconciliation across
-  nine Companies House streams and late corrective HMRC data; reduced effective
-  staleness from up to one month to three days.
-- **VRAI:** edge-to-cloud telemetry for 153 signals at 30Hz; about 4,600 events per
-  second per participant despite unreliable connectivity.
-
-[Review selected architecture work](https://maxlauriehutchinson.co.uk/work/)
-
-## Selected Public Repositories
-
-- **[Intention Engine](https://github.com/MaxLaurieHutchinson/Agent-autonomous-intention-engine):**
-  deterministic, file-first work discovery and risk routing with auditable runs
-  and replay.
-- **[Marketing Automation System](https://github.com/MaxLaurieHutchinson/marketing-automation-system):**
-  evidence-led research, measurable workflows, human feedback and staged
-  autonomy in a practical teaching system.
-- **[Agent Patterns Catalog](https://github.com/MaxLaurieHutchinson/agent-patterns):**
-  runnable Python implementations of planning, tool-use, reliability, memory and
-  event-driven coordination patterns.
-- **[Fintech Account Operations](https://github.com/MaxLaurieHutchinson/fintech-account-operations):**
-  explicit domain behaviour, transactional consistency and post-commit effects
-  in a focused .NET sample.
-
-These repositories are implementation evidence. Maturity, adoption and business
-impact are stated separately rather than implied by the existence of code.
-
-## Architecture Thesis
-
-Models produce proposals. Production systems decide what context, tools, policy,
-evidence and human authority can turn a proposal into action.
-
-That leads to four recurring design questions:
-
-1. What decision or workflow are we changing, and who owns the consequence?
-2. Which authority must remain enforceable outside the model?
-3. What evidence lets us evaluate, observe, reconstruct and improve behaviour?
-4. What would prove that accountable users trust and adopt the workflow?
+I write about the boundaries that make that practical: decision ownership,
+evaluation, observability, replay, failure handling and operating handover.
 
 [Read: The Control Plane for Applied AI Workflows](https://maxlauriehutchinson.co.uk/writing/applied-ai-control-plane/)
 
-## Direction
-
-- **Now:** own meaningful Applied AI architecture and technical direction.
-- **Next:** prove measured adoption, operating ownership and portfolio judgement.
-- **Later:** grow into Technical Director or CTO responsibility through outcomes,
-  not title inflation.
-
-## Contact
-
-- [maxlauriehutchinson.co.uk](https://maxlauriehutchinson.co.uk/)
-- [LinkedIn](https://www.linkedin.com/in/maxlauriehutchinson)
-- [max.hutchinson258@gmail.com](mailto:max.hutchinson258@gmail.com)
+[Website](https://maxlauriehutchinson.co.uk/) ·
+[Email](mailto:max.hutchinson258@gmail.com)

--- a/README.md
+++ b/README.md
@@ -1,37 +1,97 @@
 # Max Hutchinson
 
-C# Technology Lead and Technical Architect focused on distributed and deterministic systems.
+**Applied AI Systems Architect**
 
-I build event-driven platforms that must behave predictably under load, remain operable under failure, and support replayable, auditable workflows. My work spans regulated data platforms, high-throughput ingestion, and integration architectures where correctness and failure isolation matter.
+I design governed AI workflows and production platforms that teams can trust,
+operate and improve.
 
-## What I build
+My direct AI delivery is recent; the systems judgement behind it comes from 12+
+years across distributed, event-driven and high-consequence systems. I focus on
+the control surfaces that let useful AI move beyond a demo: explicit state,
+bounded tool authority, policy, evaluation, human decisions, observability,
+replay and clear operating ownership.
 
-### Platforms
-Distributed systems, integration architecture, ingestion pipelines, and observability-first operations.
+[Applied AI work](https://maxlauriehutchinson.co.uk/projects/) |
+[Enterprise cases](https://maxlauriehutchinson.co.uk/work/) |
+[Writing](https://maxlauriehutchinson.co.uk/writing/) |
+[LinkedIn](https://www.linkedin.com/in/maxlauriehutchinson)
 
-### Quant Systems
-Exploratory work on systematic trading system design with an emphasis on determinism, replay semantics, execution workflow modelling, and risk-aware controls. This focuses on infrastructure design principles rather than strategy development.
+## Evidence
 
-### Agentic Systems
-Agent orchestration patterns designed for production: policy gates, tool constraints, evaluation loops, and human-in-the-loop workflows that remain observable and governable.
+### Operated Applied AI workflow
 
-## Principles
+For Lem and Lira, I designed an AI-driven asset workflow using n8n and Azure
+Functions. It retained human review for brand and publishing decisions, reduced
+SKU go-to-market time by 90%, and removed reliance on external studio
+photography.
 
-- Radical simplicity
-- Minimise technical debt and system surface area
-- Reduce costs appropriately
-- Enable talent, to talent: strong guardrails, high autonomy
+[Read the case](https://maxlauriehutchinson.co.uk/work/lem-lira-ai-asset-workflow/)
 
-## Engineering standards
+### Current flagship prototype
 
-- Determinism and replayability by design
-- Operability first (instrumentation, debugging, failure modes)
+EvidenceGate is a human-gated engineering change-assurance prototype. It combines
+deterministic controls, policy-cited model findings, named reviewer decisions and
+tamper-evident audit events.
 
-## Background
+Its current evidence is deliberately bounded: 12 passing tests and a four-scenario
+synthetic regression set. It is a pilot-ready architecture case, not a claim of
+enterprise adoption or general model quality.
 
-12+ years building C# distributed systems across regulated and high-consequence environments including national regulation, energy platforms, SaaS systems, and real-time telemetry platforms.
+[Read the EvidenceGate case](https://maxlauriehutchinson.co.uk/projects/evidence-gate/)
+
+### Production systems foundation
+
+- **SSE Business Energy:** architecture across about 14 integrations; reduced a
+  roughly 30-day process to seconds-level digital processing.
+- **The Pensions Regulator:** deterministic ingestion and reconciliation across
+  nine Companies House streams and late corrective HMRC data; reduced effective
+  staleness from up to one month to three days.
+- **VRAI:** edge-to-cloud telemetry for 153 signals at 30Hz; about 4,600 events per
+  second per participant despite unreliable connectivity.
+
+[Review selected architecture work](https://maxlauriehutchinson.co.uk/work/)
+
+## Selected Public Repositories
+
+- [Intention Engine](https://github.com/MaxLaurieHutchinson/Agent-autonomous-intention-engine)
+  - deterministic, file-first work discovery and risk routing with auditable runs
+  and replay.
+- [Marketing Automation System](https://github.com/MaxLaurieHutchinson/marketing-automation-system)
+  - evidence-led research, measurable workflows, human feedback and staged
+  autonomy in a practical teaching system.
+- [Agent Patterns Catalog](https://github.com/MaxLaurieHutchinson/agent-patterns)
+  - runnable Python implementations of planning, tool-use, reliability, memory
+  and event-driven coordination patterns.
+- [Fintech Account Operations](https://github.com/MaxLaurieHutchinson/fintech-account-operations)
+  - explicit domain behaviour, transactional consistency and post-commit effects
+  in a focused .NET sample.
+
+These repositories are implementation evidence. Maturity, adoption and business
+impact are stated separately rather than implied by the existence of code.
+
+## Architecture Thesis
+
+Models produce proposals. Production systems decide what context, tools, policy,
+evidence and human authority can turn a proposal into action.
+
+That leads to four recurring design questions:
+
+1. What decision or workflow are we changing, and who owns the consequence?
+2. Which authority must remain enforceable outside the model?
+3. What evidence lets us evaluate, observe, reconstruct and improve behaviour?
+4. What would prove that accountable users trust and adopt the workflow?
+
+[Read: The Control Plane for Applied AI Workflows](https://maxlauriehutchinson.co.uk/writing/applied-ai-control-plane/)
+
+## Direction
+
+- **Now:** own meaningful Applied AI architecture and technical direction.
+- **Next:** prove measured adoption, operating ownership and portfolio judgement.
+- **Later:** grow into Technical Director or CTO responsibility through outcomes,
+  not title inflation.
 
 ## Contact
 
-LinkedIn: https://www.linkedin.com/in/maxlauriehutchinson  
-Website: https://www.maxlauriehutchinson.co.uk
+- [maxlauriehutchinson.co.uk](https://maxlauriehutchinson.co.uk/)
+- [LinkedIn](https://www.linkedin.com/in/maxlauriehutchinson)
+- [max.hutchinson258@gmail.com](mailto:max.hutchinson258@gmail.com)


### PR DESCRIPTION
## Summary

Refocuses the public GitHub profile on one defensible identity: **Applied AI
Systems Architect**.

- Leads with the operating proposition and architecture thesis.
- Orders evidence as operated workflow, consequential-systems foundation, then
  current R&D.
- Describes EvidenceGate as a working prototype, not a pilot or adoption result.
- Removes named-client metrics and public career-ladder language.
- Reduces the repository selection to three currently inspectable examples.
- Adds `Engineering standards I keep`, covering deterministic control,
  inspectable decisions, failure paths, explicit accountability and earned
  autonomy.
- Replaces non-ASCII separators with plain ASCII punctuation.

## Evidence boundaries

- Direct AI delivery is described as recent.
- The defensible wording is more than 12 years across software engineering,
  technical leadership and architecture; it is not 12 years of AI or
  architecture.
- EvidenceGate's local hash-linked log is not described as tamper-proof.
- Code and synthetic checks are implementation evidence, not user, adoption or
  business-impact evidence.
- Destination routes depend on website PR
  [#14](https://github.com/MaxLaurieHutchinson/Maxlauriehutchinson-website/pull/14)
  being approved and merged first.

## Validation at `799a6a9`

- `git diff --check`
- README contains ASCII text only
- Gitleaks 8.30.1 full-history scan: 22 commits, 0 findings
- Remote branch README returns HTTP 200 and contains the identity, standards
  section and corrected ASCII separators
- Final visual review of the rendered profile remains part of Max's D15 gate

## Deferred account changes

No account metadata or pin changes are authorized by this draft.

- D15 holds the GitHub profile decision.
- The D13 interim pin selection is recorded, but the profile hold controls until
  D15 is cleared.
- Public-profile release authorization remains unchecked.

## Human gate

This remains a draft. Do not merge, change account metadata or alter pins until
Max clears D15 and the relevant release authorization.
